### PR TITLE
Fix incompatibility with latest Leiningen

### DIFF
--- a/src/configleaf/core.clj
+++ b/src/configleaf/core.clj
@@ -157,13 +157,17 @@
     (if (not (.exists ns-parent-dir))
       (.mkdirs ns-parent-dir))
     (spit ns-file
-          (stencil/render-file
-           "templates/configleafns"
-           {:namespace ns-name
-            :project project
-            :project-metadata (select-keys (meta project)
-                                           [:without-profiles
-                                            :included-profiles])}))))
+          (binding [*print-dup*    false
+                    *print-meta*   false
+                    *print-length* nil
+                    *print-level*  nil]
+            (stencil/render-file
+             "templates/configleafns"
+             {:namespace ns-name
+              :project project
+              :project-metadata (select-keys (meta project)
+                                             [:without-profiles
+                                              :included-profiles])})))))
 
 (defn set-system-properties
   "Given a map of string keys to string values, sets the Java properties named


### PR DESCRIPTION
Leiningen has recently (after 2.5.3) changed the dynamic binding of `*print-dup*` in the compile task, which causes compiler errors for the namespace generated by the configleaf hook.  I further explain the issue [here](https://github.com/technomancy/leiningen/issues/2079).  In a nutshell, `print-dup`ing the entire project map is not okay, because the output may be too big for the Clojure compiler, and printing the metadata is not okay, because it contains references to Leiningen's internal functions, which will not be on the classpath when the config namespace is compiled.
